### PR TITLE
Minor fix to move a variable declaration outside a for loop

### DIFF
--- a/ci
+++ b/ci
@@ -336,12 +336,13 @@ function everest_move() {
   source repositories.sh
   local fresh=false
   local versions=""
+  local url=""
   for r in ${!hashes[@]}; do
     cd $r
     git pull
     if [[ $(git rev-parse HEAD) != ${hashes[$r]} ]]; then
       fresh=true
-      local url=${repositories[$r]#git@github.com:}
+      url=${repositories[$r]#git@github.com:}
       url="https://www.github.com/${url%.git}/compare/${hashes[$r]}...$(git rev-parse HEAD)"
       versions="$versions\n    *$r* <$url|moves to $(git rev-parse HEAD | cut -c 1-8)> on branch ${branches[$r]}"
     else


### PR DESCRIPTION
This will bother me seeing the declaration inside the for loop ... it makes more sense to have it outside. Just want it cleaned up.